### PR TITLE
'password' text is titleized. Its now 'Password'

### DIFF
--- a/app/assets/javascripts/share.js
+++ b/app/assets/javascripts/share.js
@@ -19,7 +19,7 @@ function identityIdAndMessage(identity, messageNode, hiddenElement)
     hiddenElement.val("");
   } 
   else if ( identity === "" ) {
-    messageNode.text("Type an Email, domain, IP Address, or password ");
+    messageNode.text("Type an Email, domain, IP Address, or Password ");
     hiddenElement.val("");
   }
   else if ( identity.indexOf("@") === 0 ) {

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -125,7 +125,7 @@
   <br />
   
   <h3>
-    New Sharing Rule: <br /><span id="type_mesasge">Type an Email, domain, IP Address, or <%= link_to 'password', 'javascript:void(0)', :id => 'content_password_info' %></span>
+    New Sharing Rule: <br /><span id="type_mesasge">Type an Email, domain, IP Address, or <%= link_to 'Password', 'javascript:void(0)', :id => 'content_password_info' %></span>
   </h3>
   <div id="info_about_content_password">
     <p>Content passwords are randomly generated and are used by Privly applications to permission content.</p>


### PR DESCRIPTION
I have found 2 lines of text in share.js and posts/show.html.erb. 
_Type an Email, domain, IP Address, or password_
Here the identity type 'password' is in small case. I have changed it to 'Password' to match with other identity type name.
