### PR TITLE
Updating sqlite gem name per post-install message

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'jquery-rails', '>= 2.1.3'
 
 # Database gem
 gem 'mysql2' # Comment out this line to use another Database type
-# gem 'sqlite3-ruby'
+# gem 'sqlite3'
 
 
 # Gems used only for assets and not required


### PR DESCRIPTION
Updating per post install message: 

Hello! The sqlite3-ruby gem has changed it's name to just sqlite3.  Rather than
installing `sqlite3-ruby`, you should install `sqlite3`.  Please update your
dependencies accordingly.

Thanks from the Ruby sqlite3 team!
