### PR TITLE
removed maximum lifetime config variable

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -35,6 +35,8 @@ class PostsController < ApplicationController
   # == Get the Index
   # 
   # Get a list of all the user's posts. The user must be authenticated.
+  # This listing should only be used by a privly-application so it is
+  # data-only (JSON).
   #  
   # ==== Routing  
   #
@@ -47,7 +49,7 @@ class PostsController < ApplicationController
   #
   # ==== Formats  
   #  
-  # * +html+
+  # * +html+ (deprecated)
   # * +json+ Example:
   #          [{"created_at":"2012-09-05T04:08:31Z",
   #            "burn_after_date":"2012-09-19T04:08:31Z",
@@ -88,7 +90,9 @@ class PostsController < ApplicationController
   
   # == Shows an individual post.
   #
-  # (deprecated) Use a Privly application.
+  # This endpoint is data-only, meaning you should only use the
+  # JSON format. Privly-applications integrate with this endpoint
+  # using the JSON format.
   #  
   # === Routing  
   #
@@ -97,7 +101,7 @@ class PostsController < ApplicationController
   #
   # === Formats  
   #  
-  # * +html+
+  # * +html+ (deprecated) 
   # * +json+ Example:
   #          {"created_at":"2012-09-05T04:08:31Z",
   #            "burn_after_date":"2012-09-19T04:08:31Z",
@@ -325,10 +329,7 @@ class PostsController < ApplicationController
       @post.burn_after_date = Time.now + seconds_until_burn.seconds
     elsif params[:post]["burn_after_date(1i)"]
       @post.burn_after_date = convert_date params[:post], "burn_after_date"
-    else
-      @post.burn_after_date = Time.now + Privly::Application.config.user_can_post_lifetime_max - 1.day
     end
-    
     
     if params[:post][:privly_application]
       @post.privly_application = params[:post][:privly_application]
@@ -630,10 +631,10 @@ class PostsController < ApplicationController
   def user_account_data
     
     render :json => {
-                       :csrf => form_authenticity_token,
-                       :burntAfter => Time.now + Privly::Application.config.user_can_post_lifetime_max,
-                       :canPost => user_signed_in?,
-                       :signedIn => user_signed_in?
+                      :csrf => form_authenticity_token,
+                      :burntAfter => Time.now + 30.days, # Current recommended max life
+                      :canPost => user_signed_in?,
+                      :signedIn => user_signed_in?
                      }, 
                      :callback => params[:callback]
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -33,20 +33,8 @@ class Post < ActiveRecord::Base
   # to be immediatly slotted for deletion.
   def burn_after_in_future
     if burn_after_date and burn_after_date < Time.now
-      errors.add(:burn_after_date, "#{burn_after_date} cannot be in the past, but you can destroy it now.")
-    end
-  end
-  
-  # Set the length of time content that is not associated with a user account
-  # will be stored before it is destroyed.
-  # All anonymous posts will be destroyed within two days.
-  def unauthenticated_user_settings
-    if user_id.nil? or not self.user.can_post
-      if not burn_after_date
-        errors.add(:burn_after_date, "#{burn_after_date} must be specified for anonymous posts.")
-      elsif burn_after_date > Time.now + 2.day
-        errors.add(:burn_after_date, "#{burn_after_date} cannot be more than two days into the future.")
-      end
+      errors.add(:burn_after_date, 
+      "#{burn_after_date} cannot be in the past, but you can destroy it now.")
     end
   end
   
@@ -54,14 +42,9 @@ class Post < ActiveRecord::Base
   # will be stored on the server before it is destroyed.
   def user_settings
     
-    if not self.burn_after_date
-      errors.add(:burn_after_date, "#{burn_after_date} must be specified.")
-    elsif self.burn_after_date > Time.now + Privly::Application.config.user_can_post_lifetime_max
-      errors.add(:burn_after_date, "#{burn_after_date} must be before #{Time.now + Privly::Application.config.user_can_post_lifetime_max}.")
-    end
-    
     if user_id.nil? or not self.user.can_post
-      errors.add(:burn_after_date, "Your user account cannot create content.")
+      errors.add(:burn_after_date, 
+        "Your user account cannot create content.")
     end
     
   end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -32,7 +32,7 @@
           (must be on or before the initial value)
           <%= date_select "post","burn_after_date", 
               {:default => @post.burn_after_date, 
-              :start_year => Time.now.year, :end_year => (Time.now + Privly::Application.config.user_can_post_lifetime_max).year,  
+              :start_year => Time.now.year, :end_year => (Time.now + 30.days).year,  
               :prompt => {:day => 'Choose day', :month => 'Choose month', :year => 'Choose year'}} %>
       </p>
     <% end %>   

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,10 +33,6 @@ Privly::Application.configure do
   # Set this variable to change the displayed name of the site.
   config.name = "Site Name"
 
-  # Users will be able to create posts that get deleted after this period
-  # of time.
-  config.user_can_post_lifetime_max = 30.days
-
   # The host new injectible links should be created on.
   # You should generally set this to the domain of your server
   config.link_domain_host = "localhost:3000"

--- a/config/environments/production.rb.example
+++ b/config/environments/production.rb.example
@@ -75,10 +75,6 @@ Privly::Application.configure do
   # Set this variable to change the displayed name of the site.
   config.name = "Site Name"
   
-  # Users will be able to create posts that get deleted after this period
-  # of time.
-  config.user_can_post_lifetime_max = 30.days
-  
   # The host new injectible links should be created on.
   # You should generally set this to the domain of your server
   config.link_domain_host = "domain.com"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,17 +43,6 @@ Privly::Application.configure do
   # Set this variable to change the displayed name of the site.
   config.name = "test"
   
-  # Users with the "can_post" permission will be able to create posts lasting
-  # this long
-  config.user_can_post_lifetime_max = 30.days
-  
-  # Users without the "can_post" permission will be able to create posts
-  # lasting this long. Also, their posts will not be tied to their user account
-  config.user_cant_post_lifetime_max = 14.days
-  
-  # Users who are not logged in will be able to create posts lasting this long
-  config.not_logged_in_lifetime_max = 3.days
-  
   # The host new injectible links should be created on.
   # If you don't know what you are doing here, you should set
   # it to the same domain as the primary_domain_host

--- a/test/functional/posts_controller_test.rb
+++ b/test/functional/posts_controller_test.rb
@@ -23,6 +23,15 @@ class PostsControllerTest < ActionController::TestCase
     assert_redirected_to assigns(:post).privly_URL
   end
   
+  test "should create post with seconds_until_burn" do
+    sign_in  users(:one)
+    assert_difference('Post.count') do
+      post :create, :post => {:content => "Test Post 1", :public => true,
+        :seconds_until_burn => 5}
+    end
+    assert_redirected_to assigns(:post).privly_URL
+  end
+  
   test "should create structured content post" do
     sign_in  users(:one)
     assert_difference('Post.count') do
@@ -44,7 +53,6 @@ class PostsControllerTest < ActionController::TestCase
     get :show, :id => @post.to_param, :format => "json"
     assert_response :success
   end
-  
   
   test "should deny show post" do
     sign_out users(:one)

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -69,6 +69,14 @@ class PostTest < ActiveSupport::TestCase
     post.burn_after_date = Time.now + 1.hour
     post.user = User.first
     assert post.save
+    
+    post = Post.new
+    post.public = true
+    post.content = "content"
+    post.privly_application = "PlainPost"
+    post.burn_after_date = nil
+    post.user = User.first
+    assert post.save
   end
   
 end


### PR DESCRIPTION
This pull request allows users to have content on the server that does not expire-- so the server will not automatically destroy all old content. Please note that this is a backend choice only. The UI will still default to a 30 day destruction period, but developers and users will be able to circumvent this if they know the risks inherent in long-lived content.
