### PR TITLE
added config variable for immediatly sending invitations upon request

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,5 +45,12 @@ Privly::Application.configure do
   
   # Required protocol, choose "http" or "https"
   config.required_protocol = "http"
+  
+  # Don't send invitations to users by default.
+  # Setting this to false will send users
+  # accounts when they sign up for invitations,
+  # while setting it to true will send them
+  # a message that the system is currently in closed Alpha.
+  config.send_invitations = false
 
 end

--- a/config/environments/production.rb.example
+++ b/config/environments/production.rb.example
@@ -88,4 +88,11 @@ Privly::Application.configure do
   # Required protocol, choose "http" or "https"
   config.required_protocol = "https"
   
+  # Don't send invitations to users by default.
+  # Setting this to false will send users
+  # accounts when they sign up for invitations,
+  # while setting it to true will send them
+  # a message that the system is currently in closed Alpha.
+  config.send_invitations = false
+  
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -64,4 +64,11 @@ Privly::Application.configure do
   # Required protocol, choose "http" or "https"
   config.required_protocol = "http"
   
+  # Don't send invitations to users by default.
+  # Setting this to false will send users
+  # accounts when they sign up for invitations,
+  # while setting it to true will send them
+  # a message that the system is currently in closed Alpha.
+  config.send_invitations = false
+  
 end

--- a/test/functional/invitations_controller_test.rb
+++ b/test/functional/invitations_controller_test.rb
@@ -36,7 +36,7 @@ class Users::InvitationsControllerTest < ActionController::TestCase
   end
   
   test "should obscure that user account already exists" do
-    assert_difference('Post.count', 0) do
+    assert_difference('User.count', 0) do
       post :create, {:user => {:email => users(:one).email}}
       assert_redirected_to welcome_path
       assert_equal "Thanks #{users(:one).email}! When we are ready for more users we will send you a message.", flash[:notice]
@@ -44,9 +44,9 @@ class Users::InvitationsControllerTest < ActionController::TestCase
   end
   
   test "should not create blank invitation" do
-    assert_difference('Post.count', 0) do
+    assert_difference('User.count', 0) do
       post :create, {:user => {:email => ""}}
-      assert_response :success # It will render the form again with errors
+      assert_redirected_to welcome_path
     end
   end
   


### PR DESCRIPTION
**IMPORTANT** If you have a production setup, you will need to add to your production config environment, `config.send_invitations = false` to maintain the default behavior.

This pull request adds a config environment variable so that I can easily turn automatic invitation sending on dev.privly.org on/off. We need this so developers can more easily lurk before contributing to the project.
