### PR TITLE
added ability to remove burn_after_date from posts

### DIFF
--- a/test/functional/posts_controller_test.rb
+++ b/test/functional/posts_controller_test.rb
@@ -32,6 +32,24 @@ class PostsControllerTest < ActionController::TestCase
     assert_redirected_to assigns(:post).privly_URL
   end
   
+  test "should create post with seconds_until_burn set to empty" do
+    sign_in  users(:one)
+    assert_difference('Post.count') do
+      post :create, :post => {:content => "Test Post 1", :public => true,
+        :seconds_until_burn => ""}
+    end
+    assert_redirected_to assigns(:post).privly_URL
+  end
+  
+  test "should create post with seconds_until_burn set to nil" do
+    sign_in  users(:one)
+    assert_difference('Post.count') do
+      post :create, :post => {:content => "Test Post 1", :public => true,
+        :seconds_until_burn => "nil"}
+    end
+    assert_redirected_to assigns(:post).privly_URL
+  end
+  
   test "should create structured content post" do
     sign_in  users(:one)
     assert_difference('Post.count') do


### PR DESCRIPTION
This pull request makes it possible to change the destruction period for content to blank via the `seconds_until_burn` parameter. It is up to the UI in Privly-Applications to take advantage of this.

When `seconds_until_burn` is "" or nil on update or create, the destruction date will be removed.
