### PR TITLE
increased length of structured content field to 15 megabytes

### DIFF
--- a/db/migrate/20140511230923_increase_structured_content_length.rb
+++ b/db/migrate/20140511230923_increase_structured_content_length.rb
@@ -1,0 +1,12 @@
+class IncreaseStructuredContentLength < ActiveRecord::Migration
+  def up
+    
+    # Increase the size of storage for structured content. MySQL will default
+    # to shorter text.
+    change_column :posts, :structured_content, :text, :limit => 15.megabytes
+  end
+
+  def down
+    change_column :posts, :structured_content, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140509050818) do
+ActiveRecord::Schema.define(:version => 20140511230923) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "resource_id",   :null => false
@@ -51,10 +51,10 @@ ActiveRecord::Schema.define(:version => 20140509050818) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "user_id"
-    t.boolean  "public",             :default => false, :null => false
+    t.boolean  "public",                                 :default => false, :null => false
     t.datetime "burn_after_date"
     t.string   "random_token"
-    t.text     "structured_content"
+    t.text     "structured_content", :limit => 16777215
     t.string   "privly_application"
   end
 


### PR DESCRIPTION
This pull request increases the maximum length of the structured_content field from the database default (text on mysql) to the database default that is at least 15 megabytes (mediumtext on mysql). This is to prevent truncation of longer content, like encrypted images.
