### PR TITLE
Increased session time. fixes #149

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -104,7 +104,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  config.remember_for = 2.weeks
+  config.remember_for = 4.weeks
 
   # If true, extends the user's remember period when remembered via cookie.
   config.extend_remember_period = false
@@ -125,7 +125,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 1.day
+  config.timeout_in = 2.weeks
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
This pull request increases the length of time the user stays logged in to 2 weeks from the time they last interacted with the server. It also sets the maximum length of time the user can be logged in without re-authenticating to 4 weeks.