### PR TITLE
The invitation token provided is not valid!

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -3,7 +3,7 @@
   %>
 <p>Hello <%= @resource.email %>!</p>
 
-<p>You now have a preview account at <%= root_url %>. Click to <%= link_to 'verify', accept_invitation_url(@resource, :invitation_token => @resource.invitation_token) %> your account.</p>
+<p>You now have a preview account at <%= root_url %>. Click to <%= link_to 'verify', accept_invitation_url(@resource, :invitation_token => @token) %> your account.</p>
 
 <p>We recommend you watch this <a href="https://vimeo.com/83073455">overview video</a> and if you are technically minded, this <a href="https://vimeo.com/83258935">technical video</a>.</p>
 
@@ -15,7 +15,7 @@ We are opening this server for accounts so users can influence the development o
   <strong>How to Use:</strong>
 </p>
 <ol>
-  <li>Make sure you <%= link_to 'verify your account', accept_invitation_url(@resource, :invitation_token => @resource.invitation_token) %></li>
+  <li>Make sure you <%= link_to 'verify your account', accept_invitation_url(@resource, :invitation_token => @token) %></li>
   <li>Download the extension for your browser. Either <a href="https://chrome.google.com/webstore/detail/privly/pkokikcdapfpkkkjpdaamjanniaempol">Chrome</a> or <a href="https://addons.mozilla.org/en-US/firefox/addon/privly/">Firefox</a>.</li>
   <li>Restart your browser</li>
   <li>Right-click on any text area and select "New Message"</li>

--- a/app/views/devise/mailer/confirmation_instructions.text.erb
+++ b/app/views/devise/mailer/confirmation_instructions.text.erb
@@ -3,7 +3,7 @@
   %>
 Hello <%= @resource.email %>!
 
-You now have a preview account at <%= root_url %>. Click to verify <%= accept_invitation_url(@resource, :invitation_token => @resource.invitation_token) %> your account.
+You now have a preview account at <%= root_url %>. Click to verify <%= accept_invitation_url(@resource, :invitation_token => @token) %> your account.
 
 We recommend you watch the overview video (https://vimeo.com/83073455) and if you are technically minded, technical video (https://vimeo.com/83258935).
 
@@ -12,7 +12,7 @@ Warning: Privly is currently "in alpha". You should not trust your life, liberty
 We are opening this server for accounts so users can influence the development of the system.  People who are not active members of the community may lose the ability to post new content if demands on our servers outpace our resources. If you find a problem, please report it so we can fix it for everyone.
 
 How to Use:
-1. make sure you verify your account here <%= accept_invitation_url(@resource, :invitation_token => @resource.invitation_token) %>
+1. make sure you verify your account here <%= accept_invitation_url(@resource, :invitation_token => @token) %>
 2. Download the extension for your browser. Either Chrome (https://chrome.google.com/webstore/detail/privly/pkokikcdapfpkkkjpdaamjanniaempol) or Firefox (https://addons.mozilla.org/en-US/firefox/addon/privly/)
 3. Restart your browser
 4. Right-click on any text area and select "New Message"

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -3,7 +3,7 @@
   %>
 <p>Hello <%= @resource.email %>!</p>
 
-<p>You now have a preview account at <%= root_url %>. Click to <%= link_to 'verify', accept_invitation_url(@resource, :invitation_token => @resource.invitation_token) %> your account.</p>
+<p>You now have a preview account at <%= root_url %>. Click to <%= link_to 'verify', accept_invitation_url(@resource, :invitation_token => @token) %> your account.</p>
 
 <p>We recommend you watch this <a href="https://vimeo.com/83073455">overview video</a> and if you are technically minded, this <a href="https://vimeo.com/83258935">technical video</a>.</p>
 
@@ -15,7 +15,7 @@ We are opening this server for accounts so users can influence the development o
   <strong>How to Use:</strong>
 </p>
 <ol>
-  <li>Make sure you <%= link_to 'verify your account', accept_invitation_url(@resource, :invitation_token => @resource.invitation_token) %></li>
+  <li>Make sure you <%= link_to 'verify your account', accept_invitation_url(@resource, :invitation_token => @token) %></li>
   <li>Download the extension for your browser. Either <a href="https://chrome.google.com/webstore/detail/privly/pkokikcdapfpkkkjpdaamjanniaempol">Chrome</a> or <a href="https://addons.mozilla.org/en-US/firefox/addon/privly/">Firefox</a>.</li>
   <li>Restart your browser</li>
   <li>Right-click on any text area and select "New Message"</li>

--- a/app/views/devise/mailer/invitation_instructions.text.erb
+++ b/app/views/devise/mailer/invitation_instructions.text.erb
@@ -3,7 +3,7 @@
   %>
 Hello <%= @resource.email %>!
 
-You now have a preview account at <%= root_url %>. Click to verify <%= accept_invitation_url(@resource, :invitation_token => @resource.invitation_token) %> your account.
+You now have a preview account at <%= root_url %>. Click to verify <%= accept_invitation_url(@resource, :invitation_token => @token) %> your account.
 
 We recommend you watch the overview video (https://vimeo.com/83073455) and if you are technically minded, technical video (https://vimeo.com/83258935).
 
@@ -12,7 +12,7 @@ Warning: Privly is currently "in alpha". You should not trust your life, liberty
 We are opening this server for accounts so users can influence the development of the system.  People who are not active members of the community may lose the ability to post new content if demands on our servers outpace our resources. If you find a problem, please report it so we can fix it for everyone.
 
 How to Use:
-1. make sure you verify your account here <%= accept_invitation_url(@resource, :invitation_token => @resource.invitation_token) %>
+1. make sure you verify your account here <%= accept_invitation_url(@resource, :invitation_token => @token) %>
 2. Download the extension for your browser. Either Chrome (https://chrome.google.com/webstore/detail/privly/pkokikcdapfpkkkjpdaamjanniaempol) or Firefox (https://addons.mozilla.org/en-US/firefox/addon/privly/)
 3. Restart your browser
 4. Right-click on any text area and select "New Message"


### PR DESCRIPTION
When a user clicks account verification link, provided by email, s/he gets this error ***The invitation token provided is not valid!***
As Devise has changed how token is persisted, we need to use ***@token*** instead of ***@resource.invitation_token*** in mail view.

### References
* https://github.com/scambra/devise_invitable/issues/410
* https://github.com/scambra/devise_invitable/issues/402